### PR TITLE
feat(src): configure typos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 /.config
 
 # nixago: ignore-linked-files
+/typos.toml
 /lefthook.yml
 /cog.toml
 /.conform.yaml

--- a/nix/dev/configs.nix
+++ b/nix/dev/configs.nix
@@ -24,6 +24,8 @@ in
 
   treefmt = mkNixago cfg.treefmt;
 
+  typos = mkNixago cfg.typos;
+
   githubsettings = mkNixago cfg.githubsettings {
     data.repository = {
       name = "dev-configs";

--- a/nix/dev/shells.nix
+++ b/nix/dev/shells.nix
@@ -35,6 +35,7 @@ builtins.mapAttrs (_: lib.dev.mkShell) {
       cell.configs.editorconfig
       cell.configs.githubsettings
       cell.configs.lefthook
+      cell.configs.typos
       cell.configs.treefmt
     ];
 

--- a/nix/src/cfg/typos.nix
+++ b/nix/src/cfg/typos.nix
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: 2025 Carson Henrich <carson03henrich@gmail.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+let
+  inherit (inputs) nixpkgs;
+  l = nixpkgs.lib // builtins;
+in
+{
+  data = { };
+  output = "typos.toml";
+  commands = [
+    {
+      package = nixpkgs.typos;
+      name = "typos";
+    }
+  ];
+}


### PR DESCRIPTION
Allow for the configuration of `typos` through use of nixago, so that downstream repos can specify things that shouldn't be considered to be typos.