### PR TITLE
feat(dev): allow squash and merge on github

### DIFF
--- a/nix/src/cfg/githubsettings.nix
+++ b/nix/src/cfg/githubsettings.nix
@@ -129,7 +129,7 @@ in
   data = {
     repository = {
       default_branch = "main";
-      allow_squash_merge = false;
+      allow_squash_merge = true;
       allow_merge_commit = false;
       allow_rebase_merge = true;
       delete_branch_on_merge = true;


### PR DESCRIPTION
Ran into issue where rebasing was not allowed with PR #5 and there's really no reason not to allow squash merges.