### PR TITLE
fix: github settings squash merge

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -68,7 +68,7 @@ labels:
 repository:
   allow_merge_commit: false
   allow_rebase_merge: true
-  allow_squash_merge: false
+  allow_squash_merge: true
   default_branch: main
   delete_branch_on_merge: true
   description: Base Configs for my Nix Devshells


### PR DESCRIPTION
When originally introducing the ability to perform squash-merges I did not allow the change to propagate to the `.github/settings.yml` file.