### PR TITLE
feat: configure cocogitto and modify other configs

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,70 +1,70 @@
 branches:
-  - name: main
-    protection:
-      enforce_admins: false
-      required_linear_history: true
-      required_pull_request_reviews:
-        dismiss_stale_reviews: true
-        require_code_owner_reviews: true
-        required_approving_review_count: 1
-      required_status_checks:
-        contexts: []
-        strict: true
+- name: main
+  protection:
+    enforce_admins: false
+    required_linear_history: true
+    required_pull_request_reviews:
+      dismiss_stale_reviews: true
+      require_code_owner_reviews: true
+      required_approving_review_count: 1
+    required_status_checks:
+      contexts: []
+      strict: true
 labels:
-  - color: "#000000"
-    description: This issue has been abdandoned
-    name: "Status: Abdandoned :skull:"
-  - color: "#4CAF50"
-    description: This issue has been accepted
-    name: "Status: Accepted :heavy_check_mark:"
-  - color: "#F44336"
-    description: This issue is in a blocking state
-    name: "Status: Blocked :x:"
-  - color: "#A6A6A6"
-    description: This issue is actively being worked on
-    name: "Status: In Progress :construction:"
-  - color: "#F44336"
-    description: This issue is not currently being worked on
-    name: "Status: On Hold :hourglass_flowing_sand:"
-  - color: "#FDD835"
-    description: This issue is pending a review
-    name: "Status: Review Needed :eyes:"
-  - color: "#F44336"
-    description: This issue targets a bug
-    name: "Type: Bug :bug:"
-  - color: "#FB8C00"
-    description: This issue targets general maintenance
-    name: "Type: Maintenance :wrench:"
-  - color: "#AB47BC"
-    description: This issue contains a question
-    name: "Type: Question :grey_question:"
-  - color: "#F44336"
-    description: This issue targets a security vulnerability
-    name: "Type: Security :cop:"
-  - color: "#64B5F6"
-    description: This issue targets a new feature through a story
-    name: "Type: Story :scroll:"
-  - color: "#F44336"
-    description: This issue is prioritized as critical
-    name: "Priority: 0 - Critical :zero:"
-  - color: "#FB8C00"
-    description: This issue is prioritized as high
-    name: "Priority: 1 - High :one:"
-  - color: "#4CAF50"
-    description: This issue is prioritized as low
-    name: "Priority: 3 - Low :three:"
-  - color: "#FFEE58"
-    description: This issue is prioritized as medium
-    name: "Priority: 2 - Medium :two:"
-  - color: "#4CAF50"
-    description: This issue is of low complexity or very well understood
-    name: "Effort: 1 :muscle:"
-  - color: "#FFEE58"
-    description: This issue is of medium complexity or only partly well understood
-    name: "Effort: 3 :muscle:"
-  - color: "#F44336"
-    description: This issue is of high complexity or just not yet well understood
-    name: "Effort: 5 :muscle:"
+- color: '#000000'
+  description: This issue has been abdandoned
+  name: 'Status: Abdandoned :skull:'
+- color: '#4CAF50'
+  description: This issue has been accepted
+  name: 'Status: Accepted :heavy_check_mark:'
+- color: '#F44336'
+  description: This issue is in a blocking state
+  name: 'Status: Blocked :x:'
+- color: '#A6A6A6'
+  description: This issue is actively being worked on
+  name: 'Status: In Progress :construction:'
+- color: '#F44336'
+  description: This issue is not currently being worked on
+  name: 'Status: On Hold :hourglass_flowing_sand:'
+- color: '#FDD835'
+  description: This issue is pending a review
+  name: 'Status: Review Needed :eyes:'
+- color: '#F44336'
+  description: This issue targets a bug
+  name: 'Type: Bug :bug:'
+- color: '#FB8C00'
+  description: This issue targets general maintenance
+  name: 'Type: Maintenance :wrench:'
+- color: '#AB47BC'
+  description: This issue contains a question
+  name: 'Type: Question :grey_question:'
+- color: '#F44336'
+  description: This issue targets a security vulnerability
+  name: 'Type: Security :cop:'
+- color: '#64B5F6'
+  description: This issue targets a new feature through a story
+  name: 'Type: Story :scroll:'
+- color: '#F44336'
+  description: This issue is prioritized as critical
+  name: 'Priority: 0 - Critical :zero:'
+- color: '#FB8C00'
+  description: This issue is prioritized as high
+  name: 'Priority: 1 - High :one:'
+- color: '#4CAF50'
+  description: This issue is prioritized as low
+  name: 'Priority: 3 - Low :three:'
+- color: '#FFEE58'
+  description: This issue is prioritized as medium
+  name: 'Priority: 2 - Medium :two:'
+- color: '#4CAF50'
+  description: This issue is of low complexity or very well understood
+  name: 'Effort: 1 :muscle:'
+- color: '#FFEE58'
+  description: This issue is of medium complexity or only partly well understood
+  name: 'Effort: 3 :muscle:'
+- color: '#F44336'
+  description: This issue is of high complexity or just not yet well understood
+  name: 'Effort: 5 :muscle:'
 repository:
   allow_merge_commit: false
   allow_rebase_merge: true
@@ -76,7 +76,7 @@ repository:
   has_issues: true
   has_projects: false
   has_wiki: false
-  homepage: ""
+  homepage: ''
   name: dev-configs
   private: false
   topics: nix nix-flakes devshells

--- a/nix/dev/configs.nix
+++ b/nix/dev/configs.nix
@@ -9,6 +9,7 @@
 let
   inherit (inputs.std.lib.dev) mkNixago;
   inherit (inputs.cells.src) cfg;
+  repository = "dev-configs";
 in
 {
   lefthook = mkNixago cfg.lefthook {
@@ -18,21 +19,35 @@ in
 
   conform = mkNixago cfg.conform;
 
-  cog = mkNixago cfg.cog;
-
   editorconfig = mkNixago cfg.editorconfig;
 
   treefmt = mkNixago cfg.treefmt;
 
   typos = mkNixago cfg.typos;
 
-  githubsettings = mkNixago cfg.githubsettings {
-    data.repository = {
-      name = "dev-configs";
-      inherit (import (inputs.self + /flake.nix)) description;
-      homepage = "";
-      topics = "nix nix-flakes devshells";
-      private = false;
+  cog = mkNixago cfg.cog {
+    data = {
+      inherit repository;
+      remote = "github.com";
+      owner = "ghenricc";
+      authors = [
+        {
+          signature = "Carson Henrich";
+          username = "ghenricc";
+        }
+      ];
     };
   };
+
+  githubsettings = mkNixago
+    cfg.githubsettings
+    {
+      data.repository = {
+        name = repository;
+        inherit (import (inputs.self + /flake.nix)) description;
+        homepage = "";
+        topics = "nix nix-flakes devshells";
+        private = false;
+      };
+    };
 }

--- a/nix/src/cfg/cog.nix
+++ b/nix/src/cfg/cog.nix
@@ -1,18 +1,82 @@
-# SPDX-FileCopyrightText: 2022 The Standard Authors
-#
-# SPDX-License-Identifier: Unlicense
 # SPDX-FileCopyrightText: 2025 Carson Henrich <carson03henrich@gmail.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
-# Source 1: https://github.com/divnix/std/blob/e2b20a91d37989f85d6852ebf3f55b4b9dff3cfb/src/lib/cfg/cog.nix
-# Source 2: https://github.com/divnix/std/blob/e2b20a91d37989f85d6852ebf3f55b4b9dff3cfb/src/data/configs/cog.nix
+# Config Reference: https://docs.cocogitto.io/reference/config.html
 let
   inherit (inputs) nixpkgs;
   l = nixpkgs.lib // builtins;
 in
 {
-  data = { };
+  data = {
+    tag_prefix = "v";
+    branch_whitelist = [ "main" "release/**" ];
+    changelog = {
+      template = "remote";
+    };
+    commit_types = {
+      feat = {
+        changelog_title = "Features";
+        omit_from_changelog = false;
+        bump_patch = false;
+        bump_minor = true;
+      };
+      fix = {
+        changelog_title = "Bug Fixes";
+        omit_from_changelog = false;
+        bump_patch = true;
+        bump_minor = false;
+      };
+      perf = {
+        changelog_title = "Performance Improvements";
+        omit_from_changelog = false;
+        bump_patch = true;
+        bump_minor = false;
+      };
+      refactor = {
+        changelog_title = "Refactoring";
+        omit_from_changelog = false;
+        bump_patch = false;
+        bump_minor = false;
+      };
+      test = {
+        changelog_title = "Testing";
+        omit_from_changelog = false;
+        bump_patch = false;
+        bump_minor = false;
+      };
+      build = {
+        changelog_title = "Build System";
+        omit_from_changelog = false;
+        bump_patch = false;
+        bump_minor = false;
+      };
+      ci = {
+        changelog_title = "CI";
+        omit_from_changelog = false;
+        bump_patch = false;
+        bump_minor = false;
+      };
+      docs = {
+        changelog_title = "Documentation";
+        omit_from_changelog = false;
+        bump_patch = false;
+        bump_minor = false;
+      };
+      chore = {
+        changelog_title = "Housekeeping";
+        omit_from_changelog = false;
+        bump_patch = false;
+        bump_minor = false;
+      };
+      style = {
+        changelog_title = "Formatting";
+        omit_from_changelog = false;
+        bump_patch = false;
+        bump_minor = false;
+      };
+    };
+  };
   output = "cog.toml";
   commands = [
     {

--- a/nix/src/cfg/lefthook.nix
+++ b/nix/src/cfg/lefthook.nix
@@ -47,6 +47,18 @@ in
           '';
           skip = [ "merge" "rebase" ];
         };
+        reuse = {
+          run = "${l.getExe nixpkgs.reuse} lint";
+          skip = [ "merge" "rebase" ];
+        };
+        flake-checker = {
+          run = "${l.getExe nixpkgs.flake-checker} --fail-mode";
+          skip = [ "merge" "rebase" ];
+        };
+        std = {
+          run = "${l.getExe inputs.std.packages.std} check";
+          skip = [ "merge" "rebase" ];
+        };
       };
     };
     commit-msg = {
@@ -67,12 +79,8 @@ in
           run = "${l.getExe nixpkgs.treefmt} --fail-on-change {staged_files}";
           skip = [ "merge" "rebase" ];
         };
-        reuse = {
-          run = "${l.getExe nixpkgs.reuse} lint";
-          skip = [ "merge" "rebase" ];
-        };
         typos = {
-          run = "${l.getExe nixpkgs.typos} --locale 'en-us' --no-unicode {staged_files}";
+          run = "${l.getExe nixpkgs.typos} {staged_files}";
           skip = [ "merge" "rebase" ];
         };
         # TODO Cause warnings to error, once merged https://github.com/oxalica/nil/pull/157
@@ -91,14 +99,6 @@ in
             exit $EXIT
           '';
           glob = "*.nix";
-          skip = [ "merge" "rebase" ];
-        };
-        flake-checker = {
-          run = "${l.getExe nixpkgs.flake-checker}";
-          skip = [ "merge" "rebase" ];
-        };
-        std = {
-          run = "${l.getExe inputs.std.packages.std} check";
           skip = [ "merge" "rebase" ];
         };
       };

--- a/nix/src/cfg/treefmt.nix
+++ b/nix/src/cfg/treefmt.nix
@@ -7,8 +7,9 @@
 
 # Source 1: https://github.com/divnix/std/blob/e2b20a91d37989f85d6852ebf3f55b4b9dff3cfb/src/lib/cfg/treefmt.nix
 # Source 2: https://github.com/divnix/std/blob/e2b20a91d37989f85d6852ebf3f55b4b9dff3cfb/src/data/configs/treefmt.nix
-
 # Tool Homepage: https://github.com/numtide/treefmt
+# Configuration Reference: https://treefmt.com/latest/getting-started/configure/#ci 
+
 let
   inherit (inputs) nixpkgs;
   l = nixpkgs.lib // builtins;
@@ -25,7 +26,28 @@ in
   ];
 
   data = {
-    excludes = [ "*.license" "LICENSES/**" ".gitignore" ".envrc" ".editorconfig" "flake.lock" "docs/book.toml" ];
+    excludes = [
+      "cog.toml"
+      "lefthook.yml"
+      "treefmt.toml"
+      "typos.toml"
+      "docs/book.toml"
+      ".conform.yaml"
+      ".gitignore"
+      ".envrc"
+      ".editorconfig"
+      ".github/settings.yml"
+      "LICENSES/**"
+      ".bin/**"
+      ".cache/**"
+      ".config/**"
+      ".data/**"
+      ".git/**"
+      ".github/**"
+      ".run/**"
+      "*.license"
+      "*.lock"
+    ];
     formatter = {
       nix = {
         command = l.getExe nixpkgs.nixpkgs-fmt;

--- a/nix/src/cfg/typos.nix
+++ b/nix/src/cfg/typos.nix
@@ -2,12 +2,23 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
+# Config Reference: https://github.com/crate-ci/typos/blob/master/docs/reference.md
 let
   inherit (inputs) nixpkgs;
   l = nixpkgs.lib // builtins;
 in
 {
-  data = { };
+  data = {
+    default = {
+      locale = "en-us";
+      extend-ignore-re = [
+        # Disable spellcheck on a line with `# spellchecker:disable-line`:
+        "(?Rm)^.*(#|//)\\s*spellchecker:disable-line$"
+        # Line block with `# spellchecker:<on|off>`:
+        "(?s)(#|//)\\s*spellchecker:off.*?\\n\\s*(#|//)\\s*spellchecker:on"
+      ];
+    };
+  };
   output = "typos.toml";
   commands = [
     {


### PR DESCRIPTION
Cocogitto is now configured in devshells

Moved some git hooks to pre-push from pre-commit to hopefully reduce the time it takes to commit.

Added exclusions to treefmt for all files deployed by devshells, I'd rather deal with them being misformatted than having to deal with the constant redeploys.

Also adds regexs for `typos` to allow disabling spellcheck in certain areas that cause issues.